### PR TITLE
FIX: Install otxv2 module using pip3

### DIFF
--- a/.docker/intelmq-full/Dockerfile
+++ b/.docker/intelmq-full/Dockerfile
@@ -60,7 +60,7 @@ RUN useradd -d /etc/intelmq -U -s /bin/bash intelmq \
 
 ### Install IntelMQ
 RUN cd /etc/intelmq \
-    && pip3 install hug url-normalize geolib imbox jinja2 pyasn textx tld time-machine \
+    && pip3 install hug url-normalize geolib imbox jinja2 pyasn textx tld time-machine otxv2 \
     && pip3 install --force pymisp[fileobjects,openioc,virustotal] \
     && pip3 install --no-cache-dir -e . \
     && intelmqsetup


### PR DESCRIPTION
AlienVault OTX Collector bot fails without the otxv2 python module.